### PR TITLE
Reduce # of build tasks on travis-ci.org 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,5 @@ rvm:
   - 1.9.2
   - 1.9.3
   - ruby-head
-  - rbx
   - rbx-2.0
   - jruby
-  - ree


### PR DESCRIPTION
REE is just 1.8.7 so it can be excluded in cases like this one. rbx will soon be replaced by rbx-2.0.
