### PR TITLE
Remind users about breaking changes using post_install_message

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -1,0 +1,8 @@
+# Breaking changes:
+
+* We no longer support rails-like request params, like transforming
+foo => [1, 2] to foo[]=1&foo[]=2, it would now be transformed to
+foo=1&foo=2. if you like foo[], simply pass it as foo[] => [1, 2]
+
+* This also applies to nested hash like foo => {bar => 1}. if you
+want that behaviour, just pass foo[bar] => 1.

--- a/rest-core.gemspec
+++ b/rest-core.gemspec
@@ -128,4 +128,8 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<rest-client>, [">= 0"])
   end
+
+  if File.exists?('UPGRADING')
+    s.post_install_message = File.read('UPGRADING')
+  end
 end


### PR DESCRIPTION
The way we manage gemspec `post_install_message` is copied from Paperclip https://github.com/thoughtbot/paperclip .
