### PR TITLE
Fix JRuby incompatible encoding regexp match error

### DIFF
--- a/lib/rest-core.rb
+++ b/lib/rest-core.rb
@@ -90,7 +90,7 @@ module RestCore
         c = const.const_get(n)
       rescue LoadError, NameError => e
         warn "RestCore: WARN: #{e} for #{const}\n" \
-             "  from #{e.backtrace.grep(/top.+required/).first}"
+             "  from #{e.backtrace.grep(/top.+required/u).first}"
       end
       eagerload(c, loaded) if c.respond_to?(:constants) && !loaded[n]
     }

--- a/lib/rest-core/client.rb
+++ b/lib/rest-core/client.rb
@@ -57,7 +57,7 @@ module RestCore::Client
   def inspect
     fields = if size > 0
                ' ' + attributes.map{ |k, v|
-                 "#{k}=#{v.inspect.sub(/(?<=.{12}).{4,}/, '...')}"
+                 "#{k}=#{v.inspect.sub(/(?<=.{12}).{4,}/u, '...')}"
                }.join(', ')
              else
                ''

--- a/lib/rest-core/event.rb
+++ b/lib/rest-core/event.rb
@@ -5,7 +5,7 @@ module RestCore
 
   class Event < EventStruct
     # self.class.name[/(?<=::)\w+$/] if RUBY_VERSION >= '1.9.2'
-    def name; self.class.name[/::(\w+)$/, 1]        ; end
+    def name; self.class.name[/::(\w+)$/u, 1]        ; end
     def to_s; "spent #{duration} #{name} #{message}"; end
   end
   class Event::MultiDone    < Event; end

--- a/lib/rest-core/middleware.rb
+++ b/lib/rest-core/middleware.rb
@@ -64,7 +64,7 @@ module RestCore::Middleware
     if (query = (env[REQUEST_QUERY] || {}).select{ |k, v| v }).empty?
       env[REQUEST_PATH].to_s
     else
-      q = if env[REQUEST_PATH] =~ /\?/ then '&' else '?' end
+      q = if env[REQUEST_PATH] =~ /\?/u then '&' else '?' end
       "#{env[REQUEST_PATH]}#{q}#{percent_encode(query)}"
     end
   end
@@ -81,7 +81,7 @@ module RestCore::Middleware
   end
   public :percent_encode
 
-  UNRESERVED = /[^a-zA-Z0-9\-\.\_\~]+/
+  UNRESERVED = /[^a-zA-Z0-9\-\.\_\~]+/u
   def escape string
     string.gsub(UNRESERVED) do |s|
       "%#{s.unpack('H2' * s.bytesize).join('%')}".upcase

--- a/lib/rest-core/middleware/cache.rb
+++ b/lib/rest-core/middleware/cache.rb
@@ -99,10 +99,10 @@ class RestCore::Cache
 
   def data_extract data, env, k
     _, status, headers, body =
-      data.match(/\A(\d+)\n((?:[^\n]+\n)*)\n\n(.*)\Z/m).to_a
+      data.match(/\A(\d+)\n((?:[^\n]+\n)*)\n\n(.*)\Z/um).to_a
 
     Promise.claim(env, k, body,status.to_i,
-      Hash[(headers||'').scan(/([^:]+): ([^\n]+)\n/)]).future_response
+      Hash[(headers||'').scan(/([^:]+): ([^\n]+)\n/u)]).future_response
   end
 
   def cache_for? env

--- a/lib/rest-core/middleware/json_response.rb
+++ b/lib/rest-core/middleware/json_response.rb
@@ -30,7 +30,7 @@ class RestCore::JsonResponse
   def process response
     # StackExchange returns the problematic BOM! in UTF-8, so we need to
     # strip it or it would break JSON parsers (i.e. yajl-ruby and json)
-    body = response[RESPONSE_BODY].to_s.sub(/\A\xEF\xBB\xBF/, '')
+    body = response[RESPONSE_BODY].to_s.sub(/\A\xEF\xBB\xBF/u, '')
     response.merge(RESPONSE_BODY => Json.decode("[#{body}]").first)
     # [this].first is not needed for yajl-ruby
   rescue Json.const_get(:ParseError) => error

--- a/lib/rest-core/patch/rest-client.rb
+++ b/lib/rest-core/patch/rest-client.rb
@@ -9,7 +9,7 @@ module RestClient
     # Follow a redirection
     def follow_redirection request = nil, result = nil, & block
       url = headers[:location]
-      if url !~ /^http/
+      if url !~ /^http/u
         url = URI.parse(args[:url]).merge(url).to_s
       end
       args[:url] = url

--- a/lib/rest-core/util/parse_link.rb
+++ b/lib/rest-core/util/parse_link.rb
@@ -4,12 +4,12 @@ module RestCore::ParseLink
   module_function
   # http://tools.ietf.org/html/rfc5988
   parname = '"?([^"]+)"?'
-  LINKPARAM = /#{parname}=#{parname}/
+  LINKPARAM = /#{parname}=#{parname}/u
   def parse_link link
     link.split(',').inject({}) do |r, value|
       uri, *pairs = value.split(';')
       params = Hash[pairs.map{ |p| p.strip.match(LINKPARAM)[1..2] }]
-      r[params['rel']] = params.merge('uri' => uri[/<([^>]+)>/, 1])
+      r[params['rel']] = params.merge('uri' => uri[/<([^>]+)>/u, 1])
       r
     end
   end

--- a/lib/rest-core/util/parse_query.rb
+++ b/lib/rest-core/util/parse_query.rb
@@ -12,7 +12,7 @@ module RestCore::ParseQuery
     def parse_query(qs, d = nil)
       params = {}
 
-      (qs || '').split(d ? /[#{d}] */n : /[&;] */n).each do |p|
+      (qs || '').split(d ? /[#{d}] */un : /[&;] */un).each do |p|
         k, v = p.split('=', 2).map { |x| URI.decode_www_form_component(x) }
         if cur = params[k]
           if cur.class == Array


### PR DESCRIPTION
When using jRuby 1.7.16 (and 1.7.15) in Ruby 1.9 mode, we were seeing the following error when trying to access the JSON response of the future:

```
Encoding::CompatibilityError - incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)
```

Forcing the encoding for all regexp to use utf-8 encoding fixed the problem for us.
