### PR TITLE
handle more errors in json parsing, e.g. when RESPONSE_BODY is nil wh…

### DIFF
--- a/lib/rest-core/middleware/json_response.rb
+++ b/lib/rest-core/middleware/json_response.rb
@@ -41,8 +41,13 @@ module RestCore
              end
 
       response.merge(RESPONSE_BODY => Json.decode(json))
-    rescue Json.const_get(:ParseError) => error
-      fail(response, ParseError.new(error, body))
+    rescue => error
+      case error
+      when Json.const_get(:ParseError)
+        fail(response, ParseError.new(error, body))
+      else
+        fail(response, error)
+      end
     end
   end
 end

--- a/lib/rest-core/middleware/json_response.rb
+++ b/lib/rest-core/middleware/json_response.rb
@@ -41,13 +41,10 @@ module RestCore
              end
 
       response.merge(RESPONSE_BODY => Json.decode(json))
+    rescue Json.const_get(:ParseError) => error
+      fail(response, ParseError.new(error, body))
     rescue => error
-      case error
-      when Json.const_get(:ParseError)
-        fail(response, ParseError.new(error, body))
-      else
-        fail(response, error)
-      end
+      fail(response, error)
     end
   end
 end

--- a/lib/rest-core/middleware/json_response.rb
+++ b/lib/rest-core/middleware/json_response.rb
@@ -31,6 +31,8 @@ module RestCore
       body = response[RESPONSE_BODY]
       json = if body.kind_of?(String)
                Json.normalize(body)
+             elsif body.nil?
+               Json.encode(nil)
              else
                # Yajl supports streaming, so let's pass it directly to make
                # it possible to do streaming here. Although indeed we should
@@ -43,8 +45,6 @@ module RestCore
       response.merge(RESPONSE_BODY => Json.decode(json))
     rescue Json.const_get(:ParseError) => error
       fail(response, ParseError.new(error, body))
-    rescue => error
-      fail(response, error)
     end
   end
 end

--- a/lib/rest-core/middleware/json_response.rb
+++ b/lib/rest-core/middleware/json_response.rb
@@ -31,8 +31,6 @@ module RestCore
       body = response[RESPONSE_BODY]
       json = if body.kind_of?(String)
                Json.normalize(body)
-             elsif body.nil?
-               Json.encode(nil)
              else
                # Yajl supports streaming, so let's pass it directly to make
                # it possible to do streaming here. Although indeed we should
@@ -42,7 +40,7 @@ module RestCore
                body
              end
 
-      response.merge(RESPONSE_BODY => Json.decode(json))
+      response.merge(RESPONSE_BODY => json && Json.decode(json))
     rescue Json.const_get(:ParseError) => error
       fail(response, ParseError.new(error, body))
     end

--- a/test/test_json_response.rb
+++ b/test/test_json_response.rb
@@ -20,7 +20,9 @@ describe RC::JsonResponse do
       app.call(RC::RESPONSE_BODY => '{}') do |response|
         response.should.eq(expected)
       end
+    end
 
+    would 'not decode but just return nil if response body is nil' do
       expected = {RC::RESPONSE_BODY => nil,
                   RC::REQUEST_HEADERS => {'Accept' => 'application/json'}}
       app.call({}) do |response|

--- a/test/test_json_response.rb
+++ b/test/test_json_response.rb
@@ -20,6 +20,12 @@ describe RC::JsonResponse do
       app.call(RC::RESPONSE_BODY => '{}') do |response|
         response.should.eq(expected)
       end
+
+      expected = {RC::RESPONSE_BODY => nil,
+                  RC::REQUEST_HEADERS => {'Accept' => 'application/json'}}
+      app.call({}) do |response|
+        response.should.eq(expected)
+      end
     end
 
     would 'give proper parse error' do


### PR DESCRIPTION
rescue more errors when parsing json

workaround would be to stop using callback block in requests